### PR TITLE
fix(client): プレイヤー情報テキストを見やすい色に変更

### DIFF
--- a/client/src/components/Room.tsx
+++ b/client/src/components/Room.tsx
@@ -158,6 +158,7 @@ export const Room: React.FC = () => {
               marginBottom: '5px',
               backgroundColor: player.id === gameState.playerId ? '#e3f2fd' : '#f5f5f5',
               border: player.id === gameState.currentBettorId ? '2px solid green' : '1px solid #ddd',
+              color: '#333',
             }}
           >
             <strong>{player.name}</strong> - Seat {player.seat} - Chips: {player.chips}


### PR DESCRIPTION
## Summary

Fixed unreadable white text on white background issue in the room waiting screen.

## Changes
- Added `color: '#333'` to player information display in `client/src/components/Room.tsx`
- Text is now dark gray and clearly visible against light blue and light gray backgrounds

Closes #1

Generated with [Claude Code](https://claude.ai/code)